### PR TITLE
fix: README install steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ dependencies: [
 #### Xcode
 
 1. Open your Xcode project
-2. Navigate to `File` > `Add Packages...`
+2. Navigate to `File` > `Add Package Dependencies...`
 3. Enter `https://github.com/Shopify/mobile-checkout-sdk-ios` into the search box
 4. Click `Add Package`
 


### PR DESCRIPTION
### What are you trying to accomplish?

Xcode 15 seems to have introduced new setting names

![CleanShot 2023-10-20 at 13 16 50@2x](https://github.com/Shopify/mobile-checkout-sdk-ios/assets/2399622/92752dec-a348-424c-8e3c-61b5d9374b20)

### Before you deploy

- [x] I have added tests to support my implementation
- [x] I have read and agree with the contributing documentation [readme](/.github/CONTRIBUTING.md)
- [x] I have read and agree with the code of conduct documentation [readme](/.github/CODE_OF_CONDUCT.md)
- [x] I have updated any documentation related to these changes.
- [x] I have updated the [README](/README.md) (if applicable).
