### PR TITLE
Remove white tint in web setting

### DIFF
--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/SettingsViewController.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/SettingsViewController.swift
@@ -243,7 +243,6 @@ extension Configuration.ColorScheme {
 	var navigationBarAppearance: UINavigationBarAppearance {
 		switch self {
 		case .web:
-			UIBarButtonItem.appearance().tintColor = .white
 			let navBarAppearance = UINavigationBarAppearance()
 			navBarAppearance.titleTextAttributes = [.foregroundColor: UIColor.white]
 			navBarAppearance.backgroundColor = UIColor(red: 0.19, green: 0.05, blue: 0.48, alpha: 1.00)


### PR DESCRIPTION
### What are you trying to accomplish?

Removes the white tint in the "web_browser" setting to avoid rendering the keyboard action icons in white.

### Before you deploy

- [ ] I have added tests to support my implementation
- [x] I have read and agree with the contributing documentation [readme](/.github/CONTRIBUTING.md)
- [x] I have read and agree with the code of conduct documentation [readme](/.github/CODE_OF_CONDUCT.md)
- [ ] I have updated any documentation related to these changes.
- [ ] I have updated the [README](/README.md) (if applicable).
