### PR TITLE
Show native loading spinner only on initial load

### DIFF
--- a/Sources/ShopifyCheckout/CheckoutView.swift
+++ b/Sources/ShopifyCheckout/CheckoutView.swift
@@ -25,7 +25,6 @@ import UIKit
 import WebKit
 
 protocol CheckoutViewDelegate: AnyObject {
-	func checkoutViewDidStartNavigation()
 	func checkoutViewDidCompleteCheckout()
 	func checkoutViewDidFinishNavigation()
 	func checkoutViewDidClickLink(url: URL)
@@ -155,10 +154,6 @@ extension CheckoutView: WKNavigationDelegate {
 
 		return .allow
 	}
-
-    func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
-        viewDelegate?.checkoutViewDidStartNavigation()
-    }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         viewDelegate?.checkoutViewDidFinishNavigation()

--- a/Sources/ShopifyCheckout/CheckoutViewController.swift
+++ b/Sources/ShopifyCheckout/CheckoutViewController.swift
@@ -111,8 +111,8 @@ class CheckoutViewController: UIViewController, UIAdaptivePresentationController
 			checkoutView.load(checkout: checkoutURL)
 		} else if checkoutView.isLoading && initialNavigation {
 			checkoutView.alpha = 0
-			spinner.startAnimating()
 		}
+		spinner.startAnimating()
 	}
 
 	@IBAction internal func close() {
@@ -130,13 +130,6 @@ class CheckoutViewController: UIViewController, UIAdaptivePresentationController
 }
 
 extension CheckoutViewController: CheckoutViewDelegate {
-
-	func checkoutViewDidStartNavigation() {
-		if initialNavigation {
-			spinner.startAnimating()
-		}
-	}
-
 	func checkoutViewDidFinishNavigation() {
 		spinner.stopAnimating()
 		initialNavigation = false

--- a/Tests/ShopifyCheckoutTests/Mocks/MockCheckoutViewDelegate.swift
+++ b/Tests/ShopifyCheckoutTests/Mocks/MockCheckoutViewDelegate.swift
@@ -37,10 +37,6 @@ class MockCheckoutViewDelegate: CheckoutViewDelegate {
 
 	var didFailWithErrorExpectation: XCTestExpectation?
 
-	func checkoutViewDidStartNavigation() {
-		didStartNavigationExpectation?.fulfill()
-	}
-
 	func checkoutViewDidCompleteCheckout() {
 		didCompleteCheckoutExpectation?.fulfill()
 	}


### PR DESCRIPTION
Closes https://github.com/Shopify/checkout-sdk-issues/issues/196 
Closes https://github.com/Shopify/checkout-sdk-issues/issues/207

### What are you trying to accomplish?

Instead of displayed the native spinner on every navigation, we should show the native loading spinner only on initial load. 


https://github.com/Shopify/mobile-checkout-sdk-ios/assets/89982193/909bef1a-c1ce-45ae-94ff-3e875b7b4707



### Before you deploy

- [ ] I have added tests to support my implementation
- [ ] I have read and agree with the contributing documentation [readme](/.github/CONTRIBUTING.md)
- [ ] I have read and agree with the code of conduct documentation [readme](/.github/CODE_OF_CONDUCT.md)
- [ ] I have updated any documentation related to these changes.
- [ ] I have updated the [README](/README.md) (if applicable).
