### PR TITLE
Update web colors for sample app

### DIFF
--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/SettingsViewController.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/SettingsViewController.swift
@@ -154,11 +154,7 @@ class SettingsViewController: UITableViewController {
 		case Section.colorScheme:
 			let newColorScheme = colorScheme(at: indexPath)
 			ShopifyCheckout.configuration.colorScheme = newColorScheme
-			let navigationBarAppearance = newColorScheme.navigationBarAppearance
-			UINavigationBar.appearance().standardAppearance = navigationBarAppearance
-			UINavigationBar.appearance().scrollEdgeAppearance = navigationBarAppearance
-			navigationController?.navigationBar.standardAppearance = navigationBarAppearance
-			navigationController?.navigationBar.scrollEdgeAppearance = navigationBarAppearance
+			ShopifyCheckout.configuration.spinnerColor = newColorScheme.spinnerColor
 			view?.window?.overrideUserInterfaceStyle = newColorScheme.userInterfaceStyle
             tableView.reloadSections(IndexSet(integer: Section.colorScheme.rawValue), with: .automatic)
 		default:
@@ -240,17 +236,12 @@ extension Configuration.ColorScheme {
 		}
 	}
 
-	var navigationBarAppearance: UINavigationBarAppearance {
-		switch self {
+	var spinnerColor: UIColor {
+		switch ShopifyCheckout.configuration.colorScheme {
 		case .web:
-			let navBarAppearance = UINavigationBarAppearance()
-			navBarAppearance.titleTextAttributes = [.foregroundColor: UIColor.white]
-			navBarAppearance.backgroundColor = UIColor(red: 0.19, green: 0.05, blue: 0.48, alpha: 1.00)
-			return navBarAppearance
+			return UIColor(red: 0.18, green: 0.16, blue: 0.22, alpha: 1.00)
 		default:
-			let navBarAppearance = UINavigationBarAppearance()
-			navBarAppearance.configureWithDefaultBackground()
-			return navBarAppearance
+			return UIColor(red: 0.09, green: 0.45, blue: 0.69, alpha: 1.00)
 		}
 	}
 }

--- a/Sources/ShopifyCheckout/CheckoutViewController.swift
+++ b/Sources/ShopifyCheckout/CheckoutViewController.swift
@@ -43,17 +43,9 @@ class CheckoutViewController: UIViewController, UIAdaptivePresentationController
 	private let checkoutURL: URL
 
 	private lazy var closeBarButtonItem: UIBarButtonItem = {
-		switch ShopifyCheckout.configuration.colorScheme {
-		case .web:
-			let closeIcon = UIImage(systemName: "xmark")?
-				.withConfiguration(UIImage.SymbolConfiguration(pointSize: 14, weight: .regular))
-				.withTintColor(.white, renderingMode: .alwaysOriginal)
-			return UIBarButtonItem(image: closeIcon, style: .plain, target: self, action: #selector(close))
-		default:
-			return UIBarButtonItem(
-				barButtonSystemItem: .close, target: self, action: #selector(close)
-			)
-		}
+		return UIBarButtonItem(
+			barButtonSystemItem: .close, target: self, action: #selector(close)
+		)
 	}()
 
 	// MARK: Initializers


### PR DESCRIPTION
### What are you trying to accomplish?

Updates the colors for the `web_default`  setting in the sample app

![image](https://github.com/Shopify/mobile-checkout-sdk-ios/assets/2034704/81818cc1-99d9-4b92-9cec-01a3aa6bffd9)


### Before you deploy

- [ ] I have added tests to support my implementation
- [x] I have read and agree with the contributing documentation [readme](/.github/CONTRIBUTING.md)
- [x] I have read and agree with the code of conduct documentation [readme](/.github/CODE_OF_CONDUCT.md)
- [ ] I have updated any documentation related to these changes.
- [ ] I have updated the [README](/README.md) (if applicable).
