### PR TITLE
return an error when checkout 404s. indicate to client that it may be…

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,8 +165,8 @@ extension MyViewController: ShopifyCheckoutDelegate {
 	/// You can inspect and log the Erorr and stacktrace to identify the problem.
 	case sdkError(underlying: Swift.Error)
 	
-	/// Issued when the provided checkout URL results in a 404.
-	/// The SDK only supports stores migrated for extensibility. This can be an indicator that the store is still using checkout.liquid and needs to be migrated to extensibility
+	/// Issued when the provided checkout URL results in an error related to shop being on checkout.liquid.
+	/// The SDK only supports stores migrated for extensibility. 
 	case sdkError(underlying: CheckoutLiquidError.unmigratedCheckout)
 
 	/// Unavailable error: checkout cannot be initiated or completed, e.g. due to network or server-side error

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ extension MyViewController: ShopifyCheckoutDelegate {
 	
 	/// Issued when the provided checkout URL results in an error related to shop being on checkout.liquid.
 	/// The SDK only supports stores migrated for extensibility. 
-	case sdkError(underlying: CheckoutLiquidError.unmigratedCheckout)
+	case checkoutLiquidNotMigrated(message: String)
 
 	/// Unavailable error: checkout cannot be initiated or completed, e.g. due to network or server-side error
         /// The provided message describes the error and may be logged and presented to the buyer.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 ### Requirements
 - Swift 5.7+
 - iOS SDK 13.0+
+- The SDK is not compatable with checkout.liquid. The Shopify Store must be migrated for extensibility 
 
 ### Getting Started
 The SDK is an open-source [Swift Package library](https://www.swift.org/package-manager/). As a quick start, see [sample projects](Samples/README.md) or use one of the following ways to integrate the SDK into your project:
@@ -163,6 +164,10 @@ extension MyViewController: ShopifyCheckoutDelegate {
 	/// Internal error: exception within the Checkout SDK code
 	/// You can inspect and log the Erorr and stacktrace to identify the problem.
 	case sdkError(underlying: Swift.Error)
+	
+	/// Issued when the provided checkout URL results in a 404.
+	/// The SDK only supports stores migrated for extensibility. This can be an indicator that the store is still using checkout.liquid and needs to be migrated to extensibility
+	case sdkError(underlying: CheckoutLiquidError.unmigratedCheckout)
 
 	/// Unavailable error: checkout cannot be initiated or completed, e.g. due to network or server-side error
         /// The provided message describes the error and may be logged and presented to the buyer.

--- a/Samples/MobileBuyIntegration/MobileBuyIntegration/CartViewController.swift
+++ b/Samples/MobileBuyIntegration/MobileBuyIntegration/CartViewController.swift
@@ -172,9 +172,14 @@ extension CartViewController: CheckoutDelegate {
 
 	func checkoutDidFail(error: ShopifyCheckout.CheckoutError) {
 		switch error {
-		case .sdkError(let underlying): print(#function, underlying)
+		case .sdkError(let underlying):
+			print(#function, underlying)
+			forceCloseCheckout("Checkout Unavailable")
 		case .checkoutExpired(let message): forceCloseCheckout(message)
 		case .checkoutUnavailable(let message): forceCloseCheckout(message)
+		case .checkoutLiquidNotMigrated(let message):
+			print(#function, message)
+			forceCloseCheckout("Checkout Unavailable")
 		}
 	}
 

--- a/Sources/ShopifyCheckout/CheckoutDelegate.swift
+++ b/Sources/ShopifyCheckout/CheckoutDelegate.swift
@@ -45,6 +45,10 @@ extension CheckoutDelegate {
 		handleUrl(url)
 	}
 
+	public func checkoutDidFail(error: CheckoutError) throws {
+		throw error
+	}
+
 	private func handleUrl(_ url: URL) {
 		if UIApplication.shared.canOpenURL(url) {
 			UIApplication.shared.open(url)

--- a/Sources/ShopifyCheckout/CheckoutError.swift
+++ b/Sources/ShopifyCheckout/CheckoutError.swift
@@ -39,7 +39,7 @@ public enum CheckoutError: Swift.Error {
 }
 
 public enum CheckoutLiquidError: Swift.Error {
-	/// Issued when the provided checkout URL results in a 404.
-	/// The SDK only supports stores migrated for extensibility. This can be an indicator that the store is still using checkout.liquid and needs to be migrated to extensibility
+	/// Issued when the provided checkout URL results in an error related to shop being on checkout.liquid.
+	/// The SDK only supports stores migrated for extensibility. 
 	case unmigratedCheckoutError(message: String)
 }

--- a/Sources/ShopifyCheckout/CheckoutError.swift
+++ b/Sources/ShopifyCheckout/CheckoutError.swift
@@ -37,3 +37,9 @@ public enum CheckoutError: Swift.Error {
 	/// In event of checkoutExpired, a new checkout url will need to be generated
 	case checkoutExpired(message: String)
 }
+
+public enum CheckoutLiquidError: Swift.Error {
+	/// Issued when the provided checkout URL results in a 404.
+	/// The SDK only supports stores migrated for extensibility. This can be an indicator that the store is still using checkout.liquid and needs to be migrated to extensibility
+	case unmigratedCheckoutError(message: String)
+}

--- a/Sources/ShopifyCheckout/CheckoutError.swift
+++ b/Sources/ShopifyCheckout/CheckoutError.swift
@@ -41,4 +41,3 @@ public enum CheckoutError: Swift.Error {
 	/// In event of checkoutExpired, a new checkout url will need to be generated
 	case checkoutExpired(message: String)
 }
-

--- a/Sources/ShopifyCheckout/CheckoutError.swift
+++ b/Sources/ShopifyCheckout/CheckoutError.swift
@@ -28,6 +28,10 @@ public enum CheckoutError: Swift.Error {
 	/// if the issue persists, it is recommended to open a bug report in http://github.com/Shopify/mobile-checkout-sdk-ios
 	case sdkError(underlying: Swift.Error)
 
+	/// Issued when the provided checkout URL results in an error related to shop being on checkout.liquid.
+	/// The SDK only supports stores migrated for extensibility. 
+	case checkoutLiquidNotMigrated(message: String)
+
 	/// Issued when checkout has encountered a unrecoverable error (for example server side error)
 	/// if the issue persists, it is recommended to open a bug report in http://github.com/Shopify/mobile-checkout-sdk-ios
 	case checkoutUnavailable(message: String)
@@ -38,8 +42,3 @@ public enum CheckoutError: Swift.Error {
 	case checkoutExpired(message: String)
 }
 
-public enum CheckoutLiquidError: Swift.Error {
-	/// Issued when the provided checkout URL results in an error related to shop being on checkout.liquid.
-	/// The SDK only supports stores migrated for extensibility. 
-	case unmigratedCheckoutError(message: String)
-}

--- a/Sources/ShopifyCheckout/CheckoutView.swift
+++ b/Sources/ShopifyCheckout/CheckoutView.swift
@@ -148,7 +148,7 @@ extension CheckoutView: WKNavigationDelegate {
 			case 410:
 				viewDelegate?.checkoutViewDidFailWithError(error: .checkoutExpired(message: "Checkout has expired"))
 			case 404:
-				viewDelegate?.checkoutViewDidFailWithError(error: .sdkError(underlying: CheckoutLiquidError.unmigratedCheckoutError(message: "The checkout url provided has resulted in an error. The store is still using checkout.liquid, whereas the checkout SDK only supports checkout with extensibility.")))
+				viewDelegate?.checkoutViewDidFailWithError(error: .checkoutLiquidNotMigrated(message: "The checkout url provided has resulted in an error. The store is still using checkout.liquid, whereas the checkout SDK only supports checkout with extensibility."))
 			case 500:
 				viewDelegate?.checkoutViewDidFailWithError(error: .checkoutUnavailable(message: "Checkout unavailable due to error"))
 			default:

--- a/Sources/ShopifyCheckout/CheckoutView.swift
+++ b/Sources/ShopifyCheckout/CheckoutView.swift
@@ -145,8 +145,10 @@ extension CheckoutView: WKNavigationDelegate {
 		if isCheckout(url: response.url) && response.statusCode >= 400 {
 			CheckoutView.cache = nil
 			switch response.statusCode {
-			case 404, 410:
+			case 410:
 				viewDelegate?.checkoutViewDidFailWithError(error: .checkoutExpired(message: "Checkout has expired"))
+			case 404:
+				viewDelegate?.checkoutViewDidFailWithError(error: .sdkError(underlying: CheckoutLiquidError.unmigratedCheckoutError(message: "The checkout url provided has resulted in a 404. It may be possible that the provided checkout url is not valid. It is also possible the store is still using checkout.liquid. This checkout SDK only supports checkout with extensibility. Please ensure that the store is migrated to extensibility")))
 			case 500:
 				viewDelegate?.checkoutViewDidFailWithError(error: .checkoutUnavailable(message: "Checkout unavailable due to error"))
 			default:
@@ -198,6 +200,7 @@ extension CheckoutView: WKNavigationDelegate {
 	private func isCheckout(url: URL?) -> Bool {
 		return self.url == url
 	}
+
 }
 
 extension CheckoutView {

--- a/Sources/ShopifyCheckout/CheckoutView.swift
+++ b/Sources/ShopifyCheckout/CheckoutView.swift
@@ -148,7 +148,7 @@ extension CheckoutView: WKNavigationDelegate {
 			case 410:
 				viewDelegate?.checkoutViewDidFailWithError(error: .checkoutExpired(message: "Checkout has expired"))
 			case 404:
-				viewDelegate?.checkoutViewDidFailWithError(error: .sdkError(underlying: CheckoutLiquidError.unmigratedCheckoutError(message: "The checkout url provided has resulted in a 404. It may be possible that the provided checkout url is not valid. It is also possible the store is still using checkout.liquid. This checkout SDK only supports checkout with extensibility. Please ensure that the store is migrated to extensibility")))
+				viewDelegate?.checkoutViewDidFailWithError(error: .sdkError(underlying: CheckoutLiquidError.unmigratedCheckoutError(message: "The checkout url provided has resulted in an error. The store is still using checkout.liquid, whereas the checkout SDK only supports checkout with extensibility.")))
 			case 500:
 				viewDelegate?.checkoutViewDidFailWithError(error: .checkoutUnavailable(message: "Checkout unavailable due to error"))
 			default:


### PR DESCRIPTION
… due to store using checkout.liquid

### What are you trying to accomplish?

When a shop is still on checkout.liquid, server returns a 404 as the sdk is not compatible with single page checkout. That's not been very clear to users of the sdk, so this PR throws a more descriptive stack trace and documents it

### Before you deploy

- [ ] I have added tests to support my implementation
- [x] I have read and agree with the contributing documentation [readme](/.github/CONTRIBUTING.md)
- [x] I have read and agree with the code of conduct documentation [readme](/.github/CODE_OF_CONDUCT.md)
- [x] I have updated any documentation related to these changes.
- [x] I have updated the [README](/README.md) (if applicable).
