### PR TITLE
remove unused close bridge event

### DIFF
--- a/Sources/ShopifyCheckout/CheckoutBridge.swift
+++ b/Sources/ShopifyCheckout/CheckoutBridge.swift
@@ -55,7 +55,6 @@ extension CheckoutBridge {
 extension CheckoutBridge {
 	enum WebEvent: Decodable {
 		case checkoutComplete
-		case checkoutCanceled
 		case checkoutExpired
 		case checkoutUnavailable
 		case unsupported(String)
@@ -73,8 +72,6 @@ extension CheckoutBridge {
 			switch name {
 			case "completed":
 				self = .checkoutComplete
-			case "close":
-				self = .checkoutCanceled
 			case "error":
 				// needs to support .checkoutUnavailable by parsing error payload on body
 				self = .checkoutExpired

--- a/Tests/ShopifyCheckoutTests/CheckoutBridgeTests.swift
+++ b/Tests/ShopifyCheckoutTests/CheckoutBridgeTests.swift
@@ -70,20 +70,6 @@ class CheckoutBridgeTests: XCTestCase {
 		}
 	}
 
-	func testDecodeSupportsCheckoutCanceledEvent() throws {
-		let mock = WKScriptMessageMock(body: """
-		{
-			"name": "close"
-		}
-		""")
-
-		let result = try CheckoutBridge.decode(mock)
-
-		guard case CheckoutBridge.WebEvent.checkoutCanceled = result else {
-			return XCTFail("expected CheckoutScriptMessage.checkoutCanceled, got \(result)")
-		}
-	}
-
 	func testDecodeSupportsCheckoutCompleteEvent() throws {
 		let mock = WKScriptMessageMock(body: """
 		{


### PR DESCRIPTION
### What are you trying to accomplish?

This is a hangover from when we had a web header, and needed to listen for close events from web. It's now unused and can be removed.

### Before you deploy

- [ ] I have added tests to support my implementation
- [x] I have read and agree with the contributing documentation [readme](/.github/CONTRIBUTING.md)
- [x] I have read and agree with the code of conduct documentation [readme](/.github/CODE_OF_CONDUCT.md)
- [ ] I have updated any documentation related to these changes.
- [ ] I have updated the [README](/README.md) (if applicable).
