### PR TITLE
don't invalidate preloaded cache on checkout close events

### DIFF
--- a/Sources/ShopifyCheckout/CheckoutViewController.swift
+++ b/Sources/ShopifyCheckout/CheckoutViewController.swift
@@ -116,7 +116,6 @@ class CheckoutViewController: UIViewController, UIAdaptivePresentationController
 	}
 
 	private func didCancel() {
-		CheckoutView.invalidate()
 		delegate?.checkoutDidCancel()
 	}
 }


### PR DESCRIPTION
### What are you trying to accomplish?

Originally added in this [PR](https://github.com/Shopify/mobile-checkout-sdk-ios/pull/19/files#diff-89a8f78eb54bfa9e91c749dc0df96af5ca838a629633b67b01132790a94956eaR109)

The problem we were originally looking to solve was this:
> If we enable by default but never the client never calls preload, the first time checkout is loaded will be when the user clicks the checkout button. However, it will still be cached. So imagine the user goes back to add something to their cart.. Their checkout will not be refreshed. clears the cache by calling preload.
Testing this, the result is I can complete checkout but I’m missing my added cart items (the price doesn’t change from the first iteration)
We could prevent caching until preload is called at least once.


tl;dr we wanted to ensure preload was actually called before caching, even if the preload configuration was enabled (eg by default) All in all, i do not think invalidating the cache on close is necessary

### Before you deploy

- [ ] I have added tests to support my implementation
- [x] I have read and agree with the contributing documentation [readme](/.github/CONTRIBUTING.md)
- [x] I have read and agree with the code of conduct documentation [readme](/.github/CODE_OF_CONDUCT.md)
- [ ] I have updated any documentation related to these changes.
- [ ] I have updated the [README](/README.md) (if applicable).
