### PR TITLE
Revert "don't invalidate preloaded cache on checkout close events"

### DIFF
--- a/Sources/ShopifyCheckout/CheckoutViewController.swift
+++ b/Sources/ShopifyCheckout/CheckoutViewController.swift
@@ -116,6 +116,7 @@ class CheckoutViewController: UIViewController, UIAdaptivePresentationController
 	}
 
 	private func didCancel() {
+		CheckoutView.invalidate()
 		delegate?.checkoutDidCancel()
 	}
 }


### PR DESCRIPTION
Reverts Shopify/mobile-checkout-sdk-ios#46