### PR TITLE
Prevent webview from scrolling past the bottom 0 limit

### DIFF
--- a/Sources/ShopifyCheckout/CheckoutViewController.swift
+++ b/Sources/ShopifyCheckout/CheckoutViewController.swift
@@ -56,7 +56,7 @@ class CheckoutViewController: UIViewController, UIAdaptivePresentationController
 
 		let checkoutView = CheckoutView.for(checkout: url)
 		checkoutView.translatesAutoresizingMaskIntoConstraints = false
-        checkoutView.scrollView.contentInsetAdjustmentBehavior = .never
+		checkoutView.scrollView.contentInsetAdjustmentBehavior = .never
 		self.checkoutView = checkoutView
 
 		super.init(nibName: nil, bundle: nil)
@@ -81,7 +81,7 @@ class CheckoutViewController: UIViewController, UIAdaptivePresentationController
 
 		view.addSubview(checkoutView)
 		NSLayoutConstraint.activate([
-            checkoutView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+			checkoutView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
 			checkoutView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
 			checkoutView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
 			checkoutView.bottomAnchor.constraint(equalTo: view.bottomAnchor)

--- a/Sources/ShopifyCheckout/CheckoutViewController.swift
+++ b/Sources/ShopifyCheckout/CheckoutViewController.swift
@@ -56,6 +56,7 @@ class CheckoutViewController: UIViewController, UIAdaptivePresentationController
 
 		let checkoutView = CheckoutView.for(checkout: url)
 		checkoutView.translatesAutoresizingMaskIntoConstraints = false
+        checkoutView.scrollView.contentInsetAdjustmentBehavior = .never
 		self.checkoutView = checkoutView
 
 		super.init(nibName: nil, bundle: nil)
@@ -80,7 +81,7 @@ class CheckoutViewController: UIViewController, UIAdaptivePresentationController
 
 		view.addSubview(checkoutView)
 		NSLayoutConstraint.activate([
-			checkoutView.topAnchor.constraint(equalTo: view.topAnchor),
+            checkoutView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
 			checkoutView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
 			checkoutView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
 			checkoutView.bottomAnchor.constraint(equalTo: view.bottomAnchor)


### PR DESCRIPTION
### What are you trying to accomplish?

Fix the error that happens if fixing the Pay Button to the bottom of the page. 
IOS allows the user to scroll past the bottom 0, which breaks the fixed position of the button.

Bug:

https://github.com/Shopify/mobile-checkout-sdk-ios/assets/1781007/e6a9c08f-d28b-4584-bf4e-328b5830dd00

`checkoutView.scrollView.contentInsetAdjustmentBehavior = .never`
Removing the inset auto adjustment from the view helps, but breaks the header.

https://github.com/Shopify/mobile-checkout-sdk-ios/assets/1781007/7e169a62-d896-4ae6-b5e0-967d60b89b6b

Anchoring the top of the webview to the safe area solves this issue
`checkoutView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor)`

https://github.com/Shopify/mobile-checkout-sdk-ios/assets/1781007/717286d5-40e1-44bd-becb-c3435aab2f70

No negative effects if the sticky button is disabled:

https://github.com/Shopify/mobile-checkout-sdk-ios/assets/1781007/aca13a9c-4533-4efd-ab57-e8a3ef324fcd


### Before you deploy

- [ ] I have added tests to support my implementation
- [x] I have read and agree with the contributing documentation [readme](https://github.com/shopify/mobile-checkout-sdk-ios/blob/main/.github/CONTRIBUTING.md)
- [x] I have read and agree with the code of conduct documentation [readme](https://github.com/shopify/mobile-checkout-sdk-ios/blob/main/.github/CODE_OF_CONDUCT.md)
- [ ] I have updated any documentation related to these changes.
- [ ] I have updated the [README](https://github.com/shopify/mobile-checkout-sdk-ios) (if applicable).
